### PR TITLE
feat: 견적 생성 조건 로직 추가

### DIFF
--- a/prisma/schema/schema.prisma
+++ b/prisma/schema/schema.prisma
@@ -227,12 +227,10 @@ model QuoteStatusHistory {
 /**
  * 견적 상태 종류
  * QUOTE_REQUESTED: 견적 요청
- * MOVER_SUBMITTED: 이사업자가 견적 제출
  * QUOTE_CONFIRMED: 견적 확정
  * QUOTE_CANCELED: 견적 취소
  * REQUEST_EXPIRED: 요청 만료
  * MOVE_COMPLETED: 이사 완료
- * TARGETED_QUOTE_REJECTED: 지정견적 거절
  */
 
 // 지정견적 요청

--- a/src/constants/exceptionMessages.ts
+++ b/src/constants/exceptionMessages.ts
@@ -3,4 +3,6 @@ export const EXCEPTION_MESSAGES = {
   duplicatedEmail: '중복된 이메일이 존재합니다.',
   quoteRequestNotFound: '존재하지 않는 견적요청입니다.',
   cannotCancelQuoteRequest: '취소할 수 없는 견적요청입니다.',
+  alreadyRequestedQuote: '이미 견적 요청을 하셨습니다.',
+  cannotCreateQuoteBeforeMoveNextDay: '이사일 다음날 이후에 견적 요청을 생성할 수 있습니다.',
 } as const;

--- a/src/modules/quoteRequests/repository/quoteRequests.repository.ts
+++ b/src/modules/quoteRequests/repository/quoteRequests.repository.ts
@@ -74,11 +74,6 @@ export default class QuoteRequestsRepository {
     return await this.prismaClient.quoteRequest.findFirst({
       where: {
         customerId,
-        // 견적 상태 기록 중 active 상태를 갖는 경우만 필터링(QUOTE_REQUESTED", "QUOTE_CONFIRMED")에 해당하는 요청만 반환)
-        // ...this.CANCEL_QUOTE_STATUS_HISTORY_CLAUSE,
-        currentStatus: {
-          in: ['QUOTE_REQUESTED', 'QUOTE_CONFIRMED'],
-        },
       },
       orderBy: {
         createdAt: 'desc',


### PR DESCRIPTION
- 견적 요청 생성 API, 생성 조건 로직 추가
    - 견적 요청, 견적 확정 일때는 생성 못함
    - 이사 완료 다음날에 견적 생성 가능
    - 이외, 견적 없음 / 견적 취소 / 견적 만료일때 생성 가능